### PR TITLE
Update ddclient configuration to include dropdown menu for selecting protocol

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -60,7 +60,8 @@
     "ddclient_daemon_3600s": "1 hour",
     "enable_ipv6": "Enable IPv6 automatic update",
     "ddclient_password_placeholder_leave_empty_for_unchanged": "Leave empty for unchanged password",
-    "ddclient_password_placeholder_write_password_here": "Write password here"
+    "ddclient_password_placeholder_write_password_here": "Write password here",
+    "ddclient_documentation": "The ddclient documentation {documentation}"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -41,7 +41,7 @@
     "ddclient_fqdn": "dynamic domain name (FQDN)",
     "ddclient_fqdn_tooltip": "Fully qualified domain name (FQDN) to update",
     "ddclient_protocol": "ddclient protocol",
-    "ddclient_protocol_tooltip": "Protocol to use to update the dynamic domain name: dyndns2, namecheap, noip, etc. See ddclient documentation",
+    "ddclient_protocol_tooltip": "Protocol to update the dynamic domain name: See ddclient documentation",
     "provider_fqdn": "FQDN of provider server",
     "ddclient_login": "ddclient login",
     "ddclient_password": "ddclient password",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -7,6 +7,19 @@
     <cv-row>
       <cv-column class="page-title">
         <h2>{{ $t("settings.title") }}</h2>
+        <div class="title-description mg-bottom-md">
+          <i18n path="settings.ddclient_documentation" tag="p">
+            <template v-slot:documentation>
+              <cv-link
+                href="https://ddclient.net/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                ddclient.net
+              </cv-link>
+            </template>
+          </i18n>
+        </div>
       </cv-column>
     </cv-row>
     <cv-row v-if="error.getConfiguration">
@@ -238,6 +251,7 @@ export default {
       isIpv6Enabled: false,
       ddclient_ipv6: false,
       ddclient_configured: false,
+      toggleAccordion: [false],
       loading: {
         getConfiguration: false,
         configureModule: false,

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -46,19 +46,35 @@
                 $t("settings.ddclient_fqdn_tooltip")
               }}</template>
             </NsTextInput>
-            <NsTextInput
-              :label="$t('settings.ddclient_protocol')"
-              placeholder="dyndns2"
-              v-model.trim="ddclient_protocol"
-              class="mg-bottom"
+            <cv-dropdown
+              class="maxwidth"
+              :light="true"
+              v-model="ddclient_protocol"
+              :up="false"
+              :inline="false"
+              :helper-text="$t('settings.ddclient_protocol_tooltip')"
+              :hide-selected="false"
               :invalid-message="$t(error.ddclient_protocol)"
+              :label="$t('settings.ddclient_protocol')"
               :disabled="loading.getConfiguration || loading.configureModule"
-              ref="ddclient_protocol"
             >
-              <template #tooltip>{{
-                $t("settings.ddclient_protocol_tooltip")
-              }}</template>
-            </NsTextInput>
+              <cv-dropdown-item value="changeip">changeip</cv-dropdown-item>
+              <cv-dropdown-item value="dnspark">dnspark</cv-dropdown-item>
+              <cv-dropdown-item value="dslreports1"
+                >dslreports1</cv-dropdown-item
+              >
+              <cv-dropdown-item value="duckdns">duckdns</cv-dropdown-item>
+              <cv-dropdown-item value="dyndns1">dyndns1</cv-dropdown-item>
+              <cv-dropdown-item value="dyndns2">dyndns2</cv-dropdown-item>
+              <cv-dropdown-item value="easydns">easydns</cv-dropdown-item>
+              <cv-dropdown-item value="namecheap">namecheap</cv-dropdown-item>
+              <cv-dropdown-item value="zoneedit1">zoneedit1</cv-dropdown-item>
+              <cv-dropdown-item value="googledomains"
+                >googledomains</cv-dropdown-item
+              >
+              <cv-dropdown-item value="changeip">nsupdate</cv-dropdown-item>
+              <cv-dropdown-item value="changeip">porkbun</cv-dropdown-item>
+            </cv-dropdown>
             <NsTextInput
               :label="$t('settings.provider_fqdn')"
               placeholder="providers.example.org"
@@ -81,7 +97,15 @@
             </NsTextInput>
             <NsTextInput
               :label="$t('settings.ddclient_password')"
-              :placeholder="ddclient_configured ? $t('settings.ddclient_password_placeholder_leave_empty_for_unchanged') : $t('settings.ddclient_password_placeholder_write_password_here')"
+              :placeholder="
+                ddclient_configured
+                  ? $t(
+                      'settings.ddclient_password_placeholder_leave_empty_for_unchanged'
+                    )
+                  : $t(
+                      'settings.ddclient_password_placeholder_write_password_here'
+                    )
+              "
               type="password"
               v-model.trim="ddclient_password"
               class="mg-bottom"


### PR DESCRIPTION
This pull request updates the ddclient configuration in the Settings.vue file to include a dropdown menu for selecting the protocol. Previously, the protocol was entered as a text input, but now users can choose from a list of predefined options. This improves the user experience and ensures that the correct protocol is selected.