### PR TITLE
Update ddclient configuration to use `ddclient_host` instead of `host` in Status.vue

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -19,7 +19,7 @@
     "no_services": "No services",
     "no_images": "No images",
     "no_volumes": "No volumes",
-    "ddclient_webapp": "ddclient webapp",
+    "ddclient_webapp": "dynamic DNS services",
     "not_configured": "Not configured",
     "open_webapp": "Open ddclient",
     "configure": "Configure"

--- a/ui/src/views/Status.vue
+++ b/ui/src/views/Status.vue
@@ -44,7 +44,7 @@
         <NsInfoCard
           light
           :title="$t('status.ddclient_webapp')"
-          :description="this.host ? this.host : $t('status.not_configured')"
+          :description="this.ddclient_host ? this.ddclient_host : $t('status.not_configured')"
           :icon="Wikis32"
           :loading="loading.getConfiguration"
           :isErrorShown="error.getConfiguration"
@@ -54,16 +54,6 @@
         >
           <template slot="content">
             <NsButton
-              v-if="this.host"
-              kind="ghost"
-              :icon="Launch20"
-              :disabled="loading.getConfiguration"
-              @click="goToWebapp"
-            >
-              {{ $t("status.open_webapp") }}
-            </NsButton>
-            <NsButton
-              v-else
               kind="ghost"
               :disabled="loading.getConfiguration"
               :icon="ArrowRight20"
@@ -316,7 +306,7 @@ export default {
       urlCheckInterval: null,
       isRedirectChecked: false,
       redirectTimeout: 0,
-      host: "",
+      ddclient_host: "",
       status: {
         instance: "",
         services: [],
@@ -384,9 +374,6 @@ export default {
     this.listBackupRepositories();
   },
   methods: {
-    goToWebapp() {
-      window.open(`https://${this.host}`, "_blank");
-    },
     async getConfiguration() {
       this.loading.getConfiguration = true;
       this.error.getConfiguration = "";
@@ -431,7 +418,7 @@ export default {
     },
     getConfigurationCompleted(taskContext, taskResult) {
       const config = taskResult.output;
-      this.host = config.host;
+      this.ddclient_host = config.ddclient_host;
       this.loading.getConfiguration = false;
     },
     async getStatus() {


### PR DESCRIPTION
This pull request updates the `Status.vue` file to use the `ddclient_host` variable instead of the `host` variable in the `NsInfoCard` component. This change ensures that the correct value is displayed in the description when the `ddclient_host` variable is available, falling back to the "not_configured" message when it is not.